### PR TITLE
fix build related to min/max error

### DIFF
--- a/src/Milkdrop2XBMC.cpp
+++ b/src/Milkdrop2XBMC.cpp
@@ -5,6 +5,8 @@
  *  See LICENSE.md for more information.
  */
 
+#include <kodi/addon-instance/Visualization.h>
+
 #include <windows.h>
 #include <io.h>
 #include <vector>
@@ -13,8 +15,6 @@
 #ifndef TARGET_WINDOWS
 #define TARGET_WINDOWS
 #endif
-
-#include <kodi/addon-instance/Visualization.h>
 
 CPlugin g_plugin;
 bool IsInitialized = false;

--- a/visualization.milkdrop2/addon.xml.in
+++ b/visualization.milkdrop2/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.milkdrop2"
-  version="2.4.0"
+  version="2.4.1"
   name="MilkDrop 2"
   provider-name="Ryan Geiss, ported by MrC, DX11 by afedchin">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
To fix this errors:
```
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2589: "(": Ungültiges Token auf der rechten Seite von "::" [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2062: "unknown-type"-Typ unerwartet [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
d:\dev\kodi64\_addons\alwin\visualization\visualization.milkdrop\build\build\depends\include\kodi\tools/StringUtils.h(988): error C2059: Syntaxfehler: ")" [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop-prefix\src\visualization.milkdrop-build\lib\vis_milkdrop\vis_milkdrop.vcxproj] [D:\Dev\Kodi64\_Addons\alwin\visualization\visualization.milkdrop\build\visualization.milkdrop.vcxproj]
```

There becomes it complicated about the std::min/max usage as the needed `NOMINMAX` was not available, also via cmake defines it not worked.
It seems some new included OS header unset the NOMINMAX somewhere.