### PR TITLE
increase version to 2.4.2 (to fix Jenkins deploy)

### DIFF
--- a/visualization.milkdrop2/addon.xml.in
+++ b/visualization.milkdrop2/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.milkdrop2"
-  version="2.4.1"
+  version="2.4.2"
   name="MilkDrop 2"
   provider-name="Ryan Geiss, ported by MrC, DX11 by afedchin">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Jenkins has always failed to checkout rights branch:
```
The recommended git tool is: NONE
using credential github-app-xbmc
Cloning the remote Git repository
Cloning with configured refspecs honoured and with tags
Cloning repository https://github.com/xbmc/visualization.milkdrop2.git
 > git init f:\builds\workspace\binary-addons\kodi-windows-x86_64-Matrix\tools\depends\target\binary-addons\visualization.milkdrop2 # timeout=10
Fetching upstream changes from https://github.com/xbmc/visualization.milkdrop2.git
 > git --version # timeout=10
 > git --version # 'git version 2.24.0.windows.2'
using GIT_ASKPASS to set credentials Github app for jenkins integration (xbmc org)
 > git fetch --tags --force --progress -- https://github.com/xbmc/visualization.milkdrop2.git +refs/tags/2.4.1-Matrix:refs/tags/2.4.1-Matrix # timeout=10
 > git config remote.origin.url https://github.com/xbmc/visualization.milkdrop2.git # timeout=10
 > git config --add remote.origin.fetch +refs/tags/2.4.1-Matrix:refs/tags/2.4.1-Matrix # timeout=10
Fetching with tags
Checking out Revision b855e68d3e8771fef8c8634f635aa4579dda8e32 (2.4.1-Matrix)
 > git config remote.origin.url https://github.com/xbmc/visualization.milkdrop2.git # timeout=10
Fetching upstream changes from https://github.com/xbmc/visualization.milkdrop2.git
using GIT_ASKPASS to set credentials Github app for jenkins integration (xbmc org)
 > git fetch --tags --force --progress -- https://github.com/xbmc/visualization.milkdrop2.git +refs/tags/2.4.1-Matrix:refs/tags/2.4.1-Matrix # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f b855e68d3e8771fef8c8634f635aa4579dda8e32 # timeout=10
Could not checkout b855e68d3e8771fef8c8634f635aa4579dda8e32
```

This forces him to take another branch version.