### PR TITLE
Fix build after recent build environment updates (C++ 20)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,12 +33,12 @@ jobs:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: Win32
           CONFIGURATION: Release
-          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
         Win64-UWP:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
-          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
+          WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
         #ARM32-UWP:
         #  GENERATOR: "Visual Studio 17 2022"
         #  ARCHITECTURE: ARM

--- a/lib/vis_milk2/CMakeLists.txt
+++ b/lib/vis_milk2/CMakeLists.txt
@@ -65,4 +65,7 @@ if(CORE_SYSTEM_NAME STREQUAL windowsstore)
 else()
   add_definitions(-D_WIN32_WINNT=0x0600 -D_WINDOWS)
 endif()
+
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/permissive>)
+
 add_library(vis_milk2 STATIC ${SOURCES} ${SHADER_INCLUDES})

--- a/lib/vis_milk2/vis_milk2/pluginshell.h
+++ b/lib/vis_milk2/vis_milk2/pluginshell.h
@@ -232,7 +232,7 @@ public:
     // called by vis.cpp, on behalf of Winamp:
     int  PluginPreInitialize(HWND hWinampWnd, HINSTANCE hWinampInstance);    
     //int  PluginInitialize();                                                
-	int CPluginShell::PluginInitialize( ID3D11DeviceContext* context, int iPosX, int iPosY, int iWidth, int iHeight, float pixelRatio );
+    int PluginInitialize( ID3D11DeviceContext* context, int iPosX, int iPosY, int iWidth, int iHeight, float pixelRatio );
     int  PluginRender(unsigned char *pWaveL, unsigned char *pWaveR);
     void PluginQuit();
 


### PR DESCRIPTION
Currently UWP-64 build is broken (Xbox).

Seems is since Piers branched, maybe because use of C++20 is also propagated to binary add-ons and enforces more strict conformance (/permissive).

Also is needed update Windows SDK in azure pipelines to fix other errors.